### PR TITLE
Bootstrap nucleus config system with default kancli settings(Later with store the sqlite db for the todos)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 kancli
 .DS_Store
 debug.log
+
+.idea

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/kancli/nucleus"
 )
 
 type status int
@@ -34,6 +35,9 @@ const (
 )
 
 func main() {
+	//Create the kancli nuclues
+	nucleus.Init()
+	
 	f, err := tea.LogToFile("debug.log", "debug")
 	if err != nil {
 		fmt.Println(err)

--- a/nucleus/config.go
+++ b/nucleus/config.go
@@ -1,0 +1,5 @@
+package nucleus
+
+func Init(){
+	
+}

--- a/nucleus/config.go
+++ b/nucleus/config.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	NucleusDirName  = ".kancli-nucleus" // dotfile style for home dir
+	NucleusDirName  = ".kancli-nucleus"
 	NucleusFileName = "kancli.json"
 )
 
@@ -40,8 +40,6 @@ func Init() {
 			fmt.Println("❌ Failed to create default config:", err)
 			os.Exit(1)
 		}
-	} else {
-		loadExistingConfig()
 	}
 }
 
@@ -59,7 +57,6 @@ func GetConfigDir() string {
 type KancliConfig struct {
 	Version string `json:"version"`
 	User    string `json:"user"`
-	// Add more config fields as needed
 }
 
 func createDefaultConfig() error {
@@ -86,7 +83,3 @@ func createDefaultConfig() error {
 	return nil
 }
 
-func loadExistingConfig() {
-	// Placeholder: implement loading logic here if needed
-	fmt.Println("🔁 Loading existing config from", ConfigPath)
-}

--- a/nucleus/config.go
+++ b/nucleus/config.go
@@ -1,5 +1,7 @@
 package nucleus
 
+const NUCLEUS_NAME = "kancliNuclues"
+
 func Init(){
-	
+
 }

--- a/nucleus/config.go
+++ b/nucleus/config.go
@@ -1,7 +1,92 @@
 package nucleus
 
-const NUCLEUS_NAME = "kancliNuclues"
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
 
-func Init(){
+const (
+	NucleusDirName  = ".kancli-nucleus" // dotfile style for home dir
+	NucleusFileName = "kancli.json"
+)
 
+var (
+	ConfigDir  string
+	ConfigPath string
+)
+
+func init() {
+	initConfigPaths()
+	Init()
+}
+
+func initConfigPaths() {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		fmt.Println("❌ Error: Unable to determine user home directory:", err)
+		os.Exit(1)
+	}
+
+	ConfigDir = filepath.Join(homeDir, NucleusDirName)
+	ConfigPath = filepath.Join(ConfigDir, NucleusFileName)
+}
+
+func Init() {
+	if !NucleusExists() {
+		err := createDefaultConfig()
+		if err != nil {
+			fmt.Println("❌ Failed to create default config:", err)
+			os.Exit(1)
+		}
+	} else {
+		loadExistingConfig()
+	}
+}
+
+func NucleusExists() bool {
+	_, err := os.Stat(ConfigPath)
+	return !os.IsNotExist(err)
+}
+
+func GetConfigDir() string {
+	return ConfigDir
+}
+
+// --- Default config setup ---
+
+type KancliConfig struct {
+	Version string `json:"version"`
+	User    string `json:"user"`
+	// Add more config fields as needed
+}
+
+func createDefaultConfig() error {
+	if err := os.MkdirAll(ConfigDir, 0755); err != nil {
+		return fmt.Errorf("unable to create config directory: %w", err)
+	}
+
+	defaultConfig := KancliConfig{
+		Version: "1.0.0",
+		User:    "default",
+	}
+
+	data, err := json.MarshalIndent(defaultConfig, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal default config: %w", err)
+	}
+
+	err = os.WriteFile(ConfigPath, data, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to write config file: %w", err)
+	}
+
+	fmt.Println("✅ Nucleus created at", ConfigPath)
+	return nil
+}
+
+func loadExistingConfig() {
+	// Placeholder: implement loading logic here if needed
+	fmt.Println("🔁 Loading existing config from", ConfigPath)
 }


### PR DESCRIPTION
This PR introduces the **foundational `nucleus` configuration system** for `kancli`. The goal is to create a centralized, extensible base for storing CLI state and user preferences.

Specifically, this update:

* Creates a hidden config directory at `~/.kancli-nucleus`
* Initializes a default JSON config file (`kancli.json`) if it doesn't already exist
* Adds helper utilities to check config existence and retrieve paths
* Defines a `KancliConfig` struct for structured configuration management

The module is named **`nucleus`** to reflect its role as the core of the app's persistent state and to keep things a little fun and thematic 😄.

>  In future updates, `nucleus` will also store a lightweight SQLite database in the same directory to persist user created todos locally.

### Related issue/discussion:

[https://github.com/charmbracelet/kancli/issues/2](https://github.com/charmbracelet/kancli/issues/2)
